### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#JHProgressHUD
+# JHProgressHUD
 
 JHProgressHUD is an iOS class written in Swift to display a translucent HUD with an indicator and/or labels while work is being done in a background thread. The HUD is meant as a replacement for the private UIKit UIProgressHUD.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
